### PR TITLE
fix(gemini): missing usage metadata in streaming responses

### DIFF
--- a/src/Text/Chunk.php
+++ b/src/Text/Chunk.php
@@ -24,8 +24,8 @@ readonly class Chunk
         public array $toolResults = [],
         public ?FinishReason $finishReason = null,
         public ?Meta $meta = null,
-        public ?Usage $usage = null,
         public array $additionalContent = [],
-        public ChunkType $chunkType = ChunkType::Text
+        public ChunkType $chunkType = ChunkType::Text,
+        public ?Usage $usage = null,
     ) {}
 }


### PR DESCRIPTION
## Problem

The Gemini streaming handler was not extracting token usage information from API responses, while the non-streaming text handler properly processes this metadata. This inconsistency left developers without visibility into token consumption for streaming requests, making it difficult to monitor costs and optimize usage.

## Changes

### Core Implementation
- **Extended Chunk class**: Added nullable `usage` parameter to constructor for backward compatibility
- **Implemented extractUsage() method**: Created consistent usage extraction in `Stream.php` following the same pattern as `Text.php`
- **Enhanced streaming chunks**: Modified both `processStream()` and `handleToolCalls()` methods to include usage data

### Usage Data Extracted
- Prompt tokens and completion tokens from each chunk
- Cached content token calculation for cached prompts
- Thinking tokens for advanced Gemini features
- Individual chunk usage rather than cumulative totals

### Testing
- Added comprehensive usage validation to all existing stream tests
- Verified token counts are properly extracted and non-negative
- Ensured consistency with text handler behavior

## Technical Details

The implementation mirrors the established pattern from `Text.php` by extracting `usageMetadata` fields including `promptTokenCount`, `candidatesTokenCount`, `cachedContentTokenCount`, and `thoughtsTokenCount`. The solution maintains full backward compatibility through nullable typing.

## Result

Streaming responses now provide complete token usage information consistent with non-streaming responses. Applications can track token consumption across all Gemini provider interactions regardless of streaming mode.